### PR TITLE
chore(signin): fix a typo in throw error string in case of wrong password

### DIFF
--- a/utils/authTools.ts
+++ b/utils/authTools.ts
@@ -46,7 +46,7 @@ export const signin = async ({
   const correctPW = await comparePW(password, match.password)
 
   if (!correctPW) {
-    throw new Error('invalud user')
+    throw new Error('invalid user')
   }
 
   const token = createTokenForUser(match.id)


### PR DESCRIPTION
Hey Scott, thanks for teaching another great nextjs course 💪🏻 found a small typo - fixing for consistency 🙂 

- [fix a typo in throw error in case of wrong password](https://github.com/Hendrixer/intermediate-nextjs/commit/4262114f990f539b45b4249ffaae46dd53fbf920)