### PR TITLE
refactor(attendees.ts): update total attendees query

### DIFF
--- a/utils/attendees.ts
+++ b/utils/attendees.ts
@@ -2,7 +2,7 @@ import 'server-only'
 import { db } from '@/db/db'
 import { attendees, events, rsvps } from '@/db/schema'
 import { memoize } from 'nextjs-better-unstable-cache'
-import { eq, sql } from 'drizzle-orm'
+import { eq, count } from 'drizzle-orm'
 import { delay } from './delay'
 
 export const getAttendeesCountForDashboard = memoize(
@@ -10,17 +10,18 @@ export const getAttendeesCountForDashboard = memoize(
     await delay()
     const counts = await db
       .select({
-        totalAttendees: sql`count(distinct ${attendees.id})`,
+        totalAttendees: count(attendees.id),
       })
       .from(events)
       .leftJoin(rsvps, eq(rsvps.eventId, events.id))
       .leftJoin(attendees, eq(attendees.id, rsvps.attendeeId))
       .where(eq(events.createdById, userId))
-      .groupBy(events.id)
       .execute()
 
-    const total = counts.reduce((acc, count) => acc + count.totalAttendees, 0)
-    return total
+    const [firstCount] = counts
+    const totalAttendees = firstCount.totalAttendees | 0
+
+    return totalAttendees
   },
   {
     persist: true,


### PR DESCRIPTION
### Description
--- 
- Refactored the code to use the count() function for calculating totalAttendees directly in the query.
- Removed the previous implementation that used the reduce function to calculate the total number of attendees.

### Changes Made
--- 
- Updated the query to use count(attendees.id) for counting total attendees.
- Removed the reduce function logic and replaced it with the new method of extracting totalAttendees.

```
const counts = await db
      .select({
        totalAttendees: count(attendees.id),
      })
      .from(events)
      .leftJoin(rsvps, eq(rsvps.eventId, events.id))
      .leftJoin(attendees, eq(attendees.id, rsvps.attendeeId))
      .where(eq(events.createdById, userId))
      .execute()

    const [firstCount] = counts
    const totalAttendees = firstCount.totalAttendees | 0

    return totalAttendees
```